### PR TITLE
Handle empty list separators

### DIFF
--- a/classes/ListMode.php
+++ b/classes/ListMode.php
@@ -102,7 +102,14 @@ class ListMode {
 				$this->sHeadingEnd   = '</'.$listmode.'>';
 				break;
 			case 'userformat':
-				list($this->sListStart, $this->sItemStart, $this->sItemEnd, $this->sListEnd) = $listseparators;
+				if (count($listseparators) == 4) {
+					list($this->sListStart, $this->sItemStart, $this->sItemEnd, $this->sListEnd) = $listseparators;
+				} else {
+					if (! isset($listseparators[3])) $this->sListEnd = null;
+					if (! isset($listseparators[2])) $this->sItemEnd = null;
+					if (! isset($listseparators[1])) $this->sItemStart = null;
+					if (! isset($listseparators[0])) $this->sListStart = null;
+				}
 				$this->sInline = $inlinetext;
 				break;
 		}


### PR DESCRIPTION
Fix _"PHP Notice:  Undefined offset: 3 in ~/w/extensions/DynamicPageList/classes/ListMode.php on line 97"_. Users can forget to put the 3 commas in _"listseparators"_ or _"format"_, so some parameters will not be defined and this will rise a PHP notice when calling _"list"_.

```
<DPL>
category=SomeCat
mode=userformat
listseparators=,\n* [[%TITLE%]]
</DPL>
```

```
<DPL>
category=SomeCat
format=,\n* [[%TITLE%]]
</DPL>
```

We can output an error message when we encounter an invalid syntax (without the 3 commas), but imho it will break pages in old wikis, so it is better to make these parameters empty.